### PR TITLE
github-pages static 배포 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # deptno.dev
 - vimwiki <https://deptno.dev> 웹 서버
-- 런타임에 `/mnt/data` 에 vimwiki 가 마운트 되어 있어야 실행 가능
+- 런타임에 `/mnt/data` 에 vimwiki  디렉토리가 마운트 되어 있어야 실행 가능
+- 혹은
 
 ## 환경 변수
 > 필수: m
@@ -42,6 +43,7 @@ docker -e WIKI_DIR=/mnt/data -v my-wiki-directory:/mnt/data -p 3000:3000 wiki
 
 ### 쿠버네티스
 - initContainer 등을 통해서 `/mnt/data` 에 git clone 후 사용
+- [deploy.sh](deploy.sh) 참조
 
 ### github page
 - [deploy-gh.sh](deploy-gh.sh) 참조

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # deptno.dev
-
 - vimwiki <https://deptno.dev> 웹 서버
 - 런타임에 `/mnt/data` 에 vimwiki 가 마운트 되어 있어야 실행 가능
 
@@ -39,17 +38,10 @@ docker build -t wiki .
 docker -e WIKI_DIR=/mnt/data -v my-wiki-directory:/mnt/data -p 3000:3000 wiki
 ```
 
-## 쿠버네티스
-initContainer 등을 통해서 `/mnt/data` 에 git clone 후 사용
+## 배포
 
-## todo
-- [x] 2레벨 이상의 파일 참조의 경우 링크 깨지는 것 수정 -> 아마 [...md]
-- [o] 실시간 업데이트 고민
-  - git event 를 받아서 로컬에서 pull 하는 형태의 멀티 컨테이너도 가능
-  - [x] 실시간 업데이트를 하지 않고 *웹훅을 받아 재시작*하는 형태로 초기 구현
-    - pod 가 **하나**라는 가정으로 설계됨, **스케일이 필요한 경우** 고도화 필요
-- [x] 서치 지원
-- [ ] 여러 vimwiki 의 경우도 지원
-  - [ ] clone 형태는 골아프니 github을 바로 바라 보는 게 나을 수도
-  - [x] private 위키 숨기기
-- [ ] ui
+### 쿠버네티스
+- initContainer 등을 통해서 `/mnt/data` 에 git clone 후 사용
+
+### github page
+- [deploy-gh.sh](deploy-gh.sh) 참조

--- a/apps/wiki/app/[wiki]/[...md]/page.tsx
+++ b/apps/wiki/app/[wiki]/[...md]/page.tsx
@@ -50,3 +50,16 @@ type Props = {
 export async function generateMetadata(props: Props) {
   return getMarkdownMetadata([props.params.wiki, ...props.params.md])
 }
+export async function generateStaticParams() {
+  const wiki = 'public-wiki'
+  const {files} = getAllList(wiki)
+
+  return files
+    .map(f => {
+      return {
+        wiki,
+        // slice(2) `/[wiki]` 까지 제거는
+        md: f.split('/').slice(2),
+      }
+    })
+}

--- a/apps/wiki/app/[wiki]/page.tsx
+++ b/apps/wiki/app/[wiki]/page.tsx
@@ -43,12 +43,16 @@ type Props = {
 
 export async function generateMetadata(props: Props) {
   const metadata = await getMarkdownMetadata([props.params.wiki, 'index'])
+  const url = (metadata.openGraph.url as string).slice(0, '/index'.length)
   return {
     ...metadata,
     openGraph: {
       ...metadata.openGraph,
-      url: (metadata.openGraph.url as string).slice(0, '/index'.length),
+      url,
     },
+    alternates: {
+      canonical: url,
+    }
   }
 }
 export async function generateStaticParams() {

--- a/apps/wiki/app/[wiki]/page.tsx
+++ b/apps/wiki/app/[wiki]/page.tsx
@@ -53,10 +53,6 @@ export async function generateMetadata(props: Props) {
 }
 export async function generateStaticParams() {
   return [
-    {
-      params: {
-        wiki: 'public-wiki'
-      }
-    }
+    { wiki: 'public-wiki' },
   ]
 }

--- a/apps/wiki/app/[wiki]/page.tsx
+++ b/apps/wiki/app/[wiki]/page.tsx
@@ -51,3 +51,12 @@ export async function generateMetadata(props: Props) {
     },
   }
 }
+export async function generateStaticParams() {
+  return [
+    {
+      params: {
+        wiki: 'public-wiki'
+      }
+    }
+  ]
+}

--- a/apps/wiki/app/error.tsx
+++ b/apps/wiki/app/error.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { ENDPOINT } from '../constant'
-
 export default function Error(props: Props) {
   const { error } = props
   const goRoot = () => {
@@ -13,7 +11,7 @@ export default function Error(props: Props) {
       className="flex flex-col justify-center items-center h-screen gap-8"
       onClick={goRoot}>
       <h1 className="text-8xl text-center">{error.message}</h1>
-      <div>{ENDPOINT}로 이동</div>
+      <div>첫 페이지로 이동</div>
     </div>
   )
 }

--- a/apps/wiki/app/layout.tsx
+++ b/apps/wiki/app/layout.tsx
@@ -61,7 +61,7 @@ export const metadata = {
   title: 'deptno vimwiki',
   description: 'dev log',
   referrer: 'origin-when-cross-origin',
-  keywords: ['typescript', 'kubernetes', 'react', 'react native', 'terminal', 'neovim', 'vim', 'lua'],
+  keywords: ['typescript', 'kubernetes', 'react', 'react native', 'terminal', 'neovim', 'vim', 'lua', 'frontend', 'seo', 'k9s'],
   authors: [{ name: 'deptno', url: ENDPOINT }],
   creator: 'deptno@gmail.com',
   publisher: 'deptno@gmail.com',

--- a/apps/wiki/app/not-found.tsx
+++ b/apps/wiki/app/not-found.tsx
@@ -1,0 +1,10 @@
+import { Back } from '../component/Back'
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col justify-center items-center h-screen gap-8">
+      <h1 className="text-8xl text-center">404</h1>
+      <Back>뒤로 가기</Back>
+    </div>
+  )
+}

--- a/apps/wiki/app/page.tsx
+++ b/apps/wiki/app/page.tsx
@@ -5,7 +5,7 @@ import { Markdown } from '../component/Markdown'
 import { ChildrenWithSearchResult } from '../component/ChildrenWithSearchResult'
 import { CONFIG } from '../constant'
 
-export default async function Page(props: Props) {
+export default async function Page() {
   const markdownWiki = CONFIG.map(w => `- [${w.dir}](${w.dir})`).join('\n')
 
   try {
@@ -20,11 +20,5 @@ export default async function Page(props: Props) {
   } catch (err) {
     console.error(err)
     throw err
-  }
-}
-
-type Props = {
-  params: {
-    md: string
   }
 }

--- a/apps/wiki/app/robots.ts
+++ b/apps/wiki/app/robots.ts
@@ -17,6 +17,7 @@ export default function robots(): MetadataRoute.Robots {
 
   return {
     rules,
+    // FIXME: remove hardcoded domain
     sitemap: 'https://deptno.dev/sitemap.xml',
   }
 }

--- a/apps/wiki/app/webhook/github/POST.ts
+++ b/apps/wiki/app/webhook/github/POST.ts
@@ -33,6 +33,7 @@ const file = '/webhook/github/POST'
 const restart = () => {
   console.info('restart deployment')
 
+  // FIXME: remove hardcoded domain
   const child = exec(`APISERVER=https://kubernetes.default.svc \
 SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount \
 NAMESPACE=\$(cat \${SERVICEACCOUNT}/namespace) \

--- a/apps/wiki/component/Back.tsx
+++ b/apps/wiki/component/Back.tsx
@@ -1,0 +1,18 @@
+'use client'
+import React, { ReactElement } from 'react'
+
+export function Back(props: Props) {
+  const back = () => {
+    history.back()
+  }
+
+  return (
+    <a className="cursor-pointer underline underline-offset-4" onClick={back}>
+      {props.children}
+    </a>
+  )
+}
+
+type Props = {
+  children?: ReactElement|string
+}

--- a/apps/wiki/lib/force-graph/draw.ts
+++ b/apps/wiki/lib/force-graph/draw.ts
@@ -1,4 +1,3 @@
-import { ENDPOINT } from '../../constant'
 import { ForceGraphInstance } from 'force-graph'
 
 export function draw(args: Args): Promise<ForceGraphInstance> {
@@ -21,7 +20,7 @@ export function draw(args: Args): Promise<ForceGraphInstance> {
           .zoom(zoom)
           .graphData(graphData)
           // TODO: router 가능한지 검토
-          .linkCanvasObjectMode(() => 'after').onNodeClick(node => location.href = `${ENDPOINT}/${wiki}/${node.id}`)
+          .linkCanvasObjectMode(() => 'after').onNodeClick(node => location.href = `${location.origin}/${wiki}/${node.id}`)
           .nodeCanvasObject((node, ctx, globalScale) => {
             const label = node.id
             const fontSize = 16 / globalScale

--- a/apps/wiki/lib/getPath.ts
+++ b/apps/wiki/lib/getPath.ts
@@ -2,16 +2,19 @@ import { isPublicWiki } from './isPublicWiki'
 import { prodCache } from './prodCache'
 
 export const getPath = prodCache((paths: string[]) => {
-  const [wiki, ...md] = paths.map(decodeURIComponent)
+  const decodedPaths = paths.map(decodeURIComponent)
+  const last = decodedPaths.pop()
+  const [wiki, ...md] = decodedPaths
+
   if (!isPublicWiki(wiki)) {
     return
   }
 
   const path = paths.join('/')
-  const isIndex = paths[paths.length - 1] === 'index'
+  const isIndex = last === 'index'
   const currentPath = isIndex
-    ? `/${wiki}/${md.slice(0, -1).join('/')}`
-    : md.slice(0, -1).join('/')
+    ? `/${decodedPaths.join('/')}`
+    : md.join('/')
 
   return {
     wiki,

--- a/apps/wiki/lib/getPath.ts
+++ b/apps/wiki/lib/getPath.ts
@@ -8,7 +8,10 @@ export const getPath = prodCache((paths: string[]) => {
   }
 
   const path = paths.join('/')
-  const currentPath = md.slice(0, -1).join('/')
+  const isIndex = paths[paths.length - 1] === 'index'
+  const currentPath = isIndex
+    ? `/${wiki}/${md.slice(0, -1).join('/')}`
+    : md.slice(0, -1).join('/')
 
   return {
     wiki,

--- a/apps/wiki/lib/marked/link.ts
+++ b/apps/wiki/lib/marked/link.ts
@@ -44,6 +44,7 @@ export function link(href: string, title: string, text: string) {
       if (protocol === 'mailto:') {
         const email = href.slice(protocol.length)
 
+        // FIXME: remove hardcoded domain
         return `<a href="${href}" target="_blank">${email}</a> <a href="https://mail.google.com/mail/?view=cm&fs=1&to=${email}&body=from deptno.dev" target="_blank">[지메일로 보내기]</a>`
       }
 

--- a/apps/wiki/next.config.js
+++ b/apps/wiki/next.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   reactStrictMode: true,
   transpilePackages: ['ui'],
+  output: 'export'
 }

--- a/apps/wiki/next.config.js
+++ b/apps/wiki/next.config.js
@@ -1,5 +1,4 @@
 module.exports = {
   reactStrictMode: true,
   transpilePackages: ['ui'],
-  output: 'export'
 }

--- a/deploy-gh.sh
+++ b/deploy-gh.sh
@@ -1,3 +1,10 @@
+OUTPUT=$(node -e "process.stdout.write(require('./apps/wiki/next.config.js').output ?? '')")
+
+if [ $OUTPUT != "export" ]; then
+  echo "next.config.js 에서 \`"output": "export"\` 설정 필요"
+  exit 1
+fi
+
 NEXT_PUBLIC_MEILISEARCH_HOST=https://search.deptno.dev \
 NEXT_PUBLIC_ENDPOINT=https://deptno.dev \
 DIR_WIKI_ROOT=~/workspace/src/github.com/deptno \

--- a/deploy-gh.sh
+++ b/deploy-gh.sh
@@ -1,0 +1,12 @@
+NEXT_PUBLIC_MEILISEARCH_HOST=https://search.deptno.dev \
+NEXT_PUBLIC_ENDPOINT=https://deptno.dev \
+DIR_WIKI_ROOT=~/workspace/src/github.com/deptno \
+DIR_WIKI=~/workspace/src/github.com/deptno/public-wiki \
+pnpm turbo run build
+
+touch apps/wiki/out/.nojekyll
+git -C apps/wiki/out init
+git -C apps/wiki/out add .
+git -C apps/wiki/out commit -m 'deploy commit'
+git -C apps/wiki/out remote add origin git@github.com:deptno/deptno.github.io
+git -C apps/wiki/out push -f origin @:main

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,10 @@
+OUTPUT=$(node -e "process.stdout.write(require('./apps/wiki/next.config.js').output ?? '')")
+
+if [ "$OUTPUT" != "" ]; then
+  echo "next.config.js 에서 \`output\` 속성 제거"
+  exit 1
+fi
+
 export NS=deptno
 
 TAG=latest


### PR DESCRIPTION
- 정적 배포 지원,  github pages 스크립트 추가
- 없는 페이지 접근시에 생성 전에 선 링크를 하고 있던 페이지는 못보여줌

close #14

- static 시도
- generateStaticParams 생성
- add fixme:
- generateStaticParams 구현
- */index 에 대한 예외처리 때문에 발생하는 에러로 인해 절대경로로 픽스
- github page 배포시 ceo 를 위해 canonical 추가
- static 을 위한 404
- static 빌드시 path에 //가 들어가는 경우가 없도록 조정
- deploy-gh script 추가
- ENDPOINT 하드코딩 제거
- 리드미 업데이트
- deploy script 에러처리
