### PR TITLE
fix/search console finds legacy url

### DIFF
--- a/apps/wiki/app/[wiki]/page.tsx
+++ b/apps/wiki/app/[wiki]/page.tsx
@@ -43,16 +43,21 @@ type Props = {
 }
 
 export async function generateMetadata(props: Props) {
+  console.log('generateMetadata', props)
   const metadata = await getMarkdownMetadata([props.params.wiki, 'index'])
-  const url = (metadata.openGraph.url as string).slice(0, '/index'.length)
+
+  const url = metadata
+    ? (metadata.openGraph.url as string).slice(0, '/index'.length)
+    : ''
+
   return {
     ...metadata,
     openGraph: {
-      ...metadata.openGraph,
+      ...metadata?.openGraph,
       url,
     },
     alternates: {
-      canonical: url,
+      // canonical: url,
     }
   }
 }

--- a/apps/wiki/lib/generateMetadata.ts
+++ b/apps/wiki/lib/generateMetadata.ts
@@ -8,6 +8,7 @@ export const getMarkdownMetadata = prodCache(
   async (paths: string[]): Promise<Metadata> => {
     const result = getPath(paths)
     if (!result) {
+      console.log('getMarkdownMetadata no-result', { paths })
       return
     }
 

--- a/apps/wiki/next.config.js
+++ b/apps/wiki/next.config.js
@@ -1,5 +1,13 @@
 module.exports = {
   reactStrictMode: true,
   transpilePackages: ['ui'],
-  output: 'export'
+  async redirects() {
+    return [
+      {
+        source: '/wiki/:md*',
+        destination: 'public-wiki/:md*',
+        permanent: true,
+      },
+    ]
+  },
 }

--- a/apps/wiki/public/google265ee23b6986e2a7.html
+++ b/apps/wiki/public/google265ee23b6986e2a7.html
@@ -1,0 +1,1 @@
+google-site-verification: google265ee23b6986e2a7.html


### PR DESCRIPTION
- fix: wip: add log for Cannot read properties of undefined (reading 'openGraph')
- wip: 구글 서치쪽에서 수정을 해도 예전에 등록된 url 크롤링이 들어와서 리다이렉트 임시처리
- google servch console 에 deptno.github.io 도 추가
