### PR TITLE
Next.js 보안 패치 적용

### DIFF
--- a/apps/wiki/next-env.d.ts
+++ b/apps/wiki/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/wiki/package.json
+++ b/apps/wiki/package.json
@@ -17,7 +17,7 @@
     "marked-gfm-heading-id": "^3.2.0",
     "marked-highlight": "^2.2.2",
     "mermaid": "^10",
-    "next": "~15.5.16",
+    "next": "~15.5.18",
     "parser-vimwiki": "workspace:^",
     "prismjs": "^1.30.0",
     "react": "19.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         specifier: ^10
         version: 10.9.3
       next:
-        specifier: ~15.5.16
+        specifier: ~15.5.18
         version: 15.5.18(react-dom@19.1.7(react@19.1.7))(react@19.1.7)
       parser-vimwiki:
         specifier: workspace:^


### PR DESCRIPTION
## 요약
- Next.js 보안 패치: `next` -> `~15.5.18`
- pnpm lock 기준으로 의존성 갱신

## 배포
- 스크립트: `deploy.sh`
- 위치: `deptno/deployment/wiki`
- 이미지: `harbor.deptno.dev/deptno/wiki:2aa4bc7`
- 검증: rollout 성공, `https://wiki.deptno.dev` 200

## 관련 PR
- https://github.com/deptno/deptno.dev/pull/2
- https://github.com/deptno-ai/language-subtitle/pull/16
- https://github.com/deptno/wiki.deptno.dev/pull/28
- https://github.com/deptno/codex-mon/pull/10
- https://github.com/deptno/textube.deptno.dev/pull/5
- https://github.com/deptno/data-kpop/pull/24
- https://github.com/deptno/salji.ro/pull/698